### PR TITLE
Fix GitHub org link

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,7 +91,7 @@
   <h1>Bora QA</h1>
   <h4>Compartilhando conhecimento e andando juntos</h4>
   <div class="socials">
-    <Social name="github" link="https://github.com/Bora-QA/Sobre" />
+    <Social name="github" link="https://github.com/Bora-QA" />
     <Social name="youtube" link="https://www.youtube.com/channel/UC3LbaeH6nmbi4nhXrwLimVA" />
   </div>
 </header>


### PR DESCRIPTION
When accessing https://boraqa.org and clicking the GitHub logo, it is redirecting me to a 404 Page not found.

This PR fixes this broken link.